### PR TITLE
New Promeatheus map version 1.4.5 on Bonetome

### DIFF
--- a/CustomMaps/Promeatheus/1.4.5.json
+++ b/CustomMaps/Promeatheus/1.4.5.json
@@ -1,12 +1,12 @@
 {
   "Name": "Promeatheus",
-  "VersionNumber": "1.4.4",
+  "VersionNumber": "1.4.5",
   "Description": "Promeatheus is a sci-fi themed Take and Hold map. It is an indoor map that features a mix of short and long hallways, small and medium sized holds/supply points, and shiny floors.\r\n\r\nPerformance:\r\nI recommend turning off HDR and Bloom. I tuned the lighting to look good with HDR off. Also the map still looks good even on the Low setting.\r\n\r\nStory(?):\r\nWhy is the Weinerland-Umami Corporation guarding this abandoned science vessel? Your mission is to investigate the Promeatheus and recover any valuable information you can.",
   "ShortDescription": "Sci-fi themed map for Take and Hold",
   "Authors": ["NunSuperior"],
-  "IconUrl": "https://avatars.githubusercontent.com/u/4492649?s=460&v=4",
+  "IconUrl": "https://i.imgur.com/TKu71elm.jpg",
   "SourceUrl": "https://bonetome.com/h3vr/map/198/",
-  "DownloadUrl": "https://bonetome.com/download.php?file=YmQ1ZWFmZjgzZWU3NzVmMiszODErOTk4",
+  "DownloadUrl": "https://bonetome.com/download.php?file=YmQ1ZWFmZjgzZWU3NzVmMisxMjYwKzk5OA==",
   "InstallationSteps": ["extract $GAME_DIR\\Mods"],
   "Dependencies": {
     "WurstMod": "2.0.2"


### PR DESCRIPTION
Ported Promeatheus map file to new Deli 0.3 version. These changes pick up that new Deli file on Bonetome.
Replaced IconUrl with the one that is used on Bonetome for the map.
Incremented version number to match new Promeatheus map version 1.4.5