### PR TITLE
Update 8.0.0.json

### DIFF
--- a/CustomObjects/PCCG/8.0.0.json
+++ b/CustomObjects/PCCG/8.0.0.json
@@ -11,11 +11,12 @@
   ],
   "DownloadUrl": "https://bonetome.com/download.php?file=NGFmYTMxOWRjNmEwMTdhMSsrNzUw",
   "Dependencies": {
-    "LSIIC": "^1.3.0",
-    "H3VRUtils": "*"
+    "Deli": "^3.0",
+    "H3VRUtils": "^7.1.0",
+    "OtherLoader": "^1.6.0"
   },
   "InstallationSteps": [
-    "extract $GAME_DIR/VirtualObjects"
+    "extract $GAME_DIR/Deli/Mods"
   ],
   "IsBeta": false
 }


### PR DESCRIPTION
PCCG 8.0.0.json points the extraction of the downloaded zip to the wrong folder. It is a deli mod file now. The dependencies also changed. 
Dependencies:
Deli 3.0+
H3VRUtils 7.1.0+
OtherLoader 1.6.0+ ?(Not sure if 1.4.0 will work)
I do not know the proper Dependencies entries for the json so please correct them if needed.