### PR TITLE
Fixed thunderstore release bug

### DIFF
--- a/BehaviourMods/NToolbox/1.2.3.json
+++ b/BehaviourMods/NToolbox/1.2.3.json
@@ -8,7 +8,7 @@
   "Authors": [
     "Gamernayr"
   ],
-  "DownloadUrl": "https://github.com/nayr31/N-Toolbox/releases/download/v1.2.3/nayr31-NToolbox.zip",
+  "DownloadUrl": "https://github.com/nayr31/N-Toolbox/releases/download/v1.2.3/NToolbox.deli",
   "Dependencies": {
     "Deli.H3VR": "^0.2.0"
   },


### PR DESCRIPTION
Auto-bot made the thunderstore zip the target as I released a wonk version. This change just targets the original deli file just in case