### PR TITLE
Update 1.5.0.json

### DIFF
--- a/CustomMaps/ShootyRange/1.5.0.json
+++ b/CustomMaps/ShootyRange/1.5.0.json
@@ -7,7 +7,7 @@
   "IconUrl": "https://i.imgur.com/TaFPCSn.png",
   "SourceUrl": "https://bonetome.com/h3vr/map/5/",
   "DownloadUrl": "https://bonetome.com/download.php?file=ZGU0Nzk1NTk4ZGEyN2Y3OCsrMzU5",
-  "InstallationSteps": ["extract $GAME_DIR\\Deli\\mods\\"],
+  "InstallationSteps": ["extract $GAME_DIR\\Deli\\mods\\legacy\\CustomLevels\\Other"],
   "Dependencies": {
     "WurstMod": "^2.0.3"
   }

--- a/CustomMaps/ShootyRange/1.5.0.json
+++ b/CustomMaps/ShootyRange/1.5.0.json
@@ -9,6 +9,7 @@
   "DownloadUrl": "https://bonetome.com/download.php?file=ZGU0Nzk1NTk4ZGEyN2Y3OCsrMzU5",
   "InstallationSteps": ["extract $GAME_DIR\\Deli\\mods\\legacy\\CustomLevels\\Other"],
   "Dependencies": {
-    "WurstMod": "^2.0.3"
+    "WurstMod": "^2.0.3",
+    "OtherLoader": "*"
   }
 }


### PR DESCRIPTION
Change the installation directory as Shooty Range is a legacy mod

Is there any way to change the installation directory based on what other mods are installed (OtherLoader changes where it should be installed so the install directory is correct for it and is listed as a dependency)